### PR TITLE
Fixes for OMNode and WSSec code issues with wss4j upgrade

### DIFF
--- a/modules/rampart-core/src/main/java/org/apache/rampart/builder/AsymmetricBindingBuilder.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/builder/AsymmetricBindingBuilder.java
@@ -693,7 +693,7 @@ public class AsymmetricBindingBuilder extends BindingBuilder {
                 setupEncryptedKey(rmd, sigToken);
             }
             
-            WSSecDKSign dkSign = new WSSecDKSign(doc);
+            WSSecDKSign dkSign = new WSSecDKSign(rmd.getSecHeader());
 
             dkSign.setTokenIdentifier(this.encryptedKeyId);
 

--- a/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAML2TokenIssuer.java
+++ b/modules/rampart-trust/src/main/java/org/apache/rahas/impl/SAML2TokenIssuer.java
@@ -541,7 +541,7 @@ public class SAML2TokenIssuer implements TokenIssuer {
 
             //Marshall and Sign
             Marshaller marshaller = XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(assertion);
-            marshaller.marshall(assertion);
+            marshaller.marshall(assertion,document);
 
             Signer.signObjects(signatureList);
 


### PR DESCRIPTION
2 fixes as described in Jira : RAMPART-449

1. The OMNode issue is as a result of some code that got changed in SAML2TokenIssuer.java:544. 'document' was removed as a parameter, causing xerces rather than axiom elements to be created (which therefore can't be cast to OMNode later). Just adding the document back in fixes this.
2. When the newer version of WSSecDKSign was used (wss4j upgrade) it required a constructor parameter (AsymmetricBindingBuilder.java:696) and doc was passed in. It needed the other constructor (passing the security header using rmd.getSecHeader() ). Otherwise it gets a null pointer when it looks for it later.
