### PR TITLE
Conversation constant update

### DIFF
--- a/modules/rampart-tests/src/test/java/org/apache/rampart/AsymmetricBindingBuilderTest.java
+++ b/modules/rampart-tests/src/test/java/org/apache/rampart/AsymmetricBindingBuilderTest.java
@@ -84,7 +84,7 @@ public class AsymmetricBindingBuilderTest extends MessageBuilderTestBase {
         list.add(new QName(WSConstants.WSU_NS, WSConstants.TIMESTAMP_TOKEN_LN));
         list.add(new QName(WSConstants.WSSE_NS, WSConstants.BINARY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_KEY_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.SIG_NS, WSConstants.SIG_LN));
 
         
@@ -107,7 +107,7 @@ public class AsymmetricBindingBuilderTest extends MessageBuilderTestBase {
         list.add(new QName(WSConstants.WSU_NS, WSConstants.TIMESTAMP_TOKEN_LN));
         list.add(new QName(WSConstants.WSSE_NS, WSConstants.BINARY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_KEY_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.SIG_NS, WSConstants.SIG_LN));
         
         this.verifySecHeader(list.iterator(), ctx.getEnvelope());
@@ -128,9 +128,9 @@ public class AsymmetricBindingBuilderTest extends MessageBuilderTestBase {
         
         list.add(new QName(WSConstants.WSU_NS, WSConstants.TIMESTAMP_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_KEY_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.SIG_NS, WSConstants.SIG_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.REF_LIST_LN));
          
         this.verifySecHeader(list.iterator(), ctx.getEnvelope());
@@ -196,9 +196,9 @@ public class AsymmetricBindingBuilderTest extends MessageBuilderTestBase {
         list.add(new QName(WSConstants.WSU_NS, WSConstants.TIMESTAMP_TOKEN_LN));
         list.add(new QName(WSConstants.WSSE_NS,WSConstants.BINARY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_KEY_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.REF_LIST_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.SIG_NS, WSConstants.SIG_LN));
         
         this.verifySecHeader(list.iterator(), ctx.getEnvelope());

--- a/modules/rampart-tests/src/test/java/org/apache/rampart/SymmetricBindingBuilderTest.java
+++ b/modules/rampart-tests/src/test/java/org/apache/rampart/SymmetricBindingBuilderTest.java
@@ -92,9 +92,9 @@ public class SymmetricBindingBuilderTest extends MessageBuilderTestBase {
         
         list.add(new QName(WSConstants.WSU_NS, WSConstants.TIMESTAMP_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_KEY_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.REF_LIST_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.SIG_NS, WSConstants.SIG_LN));
         
         this.verifySecHeader(list.iterator(), ctx.getEnvelope());
@@ -116,9 +116,9 @@ public class SymmetricBindingBuilderTest extends MessageBuilderTestBase {
         
         list.add(new QName(WSConstants.WSU_NS, WSConstants.TIMESTAMP_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_KEY_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.REF_LIST_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_DATA_LN));
         
         this.verifySecHeader(list.iterator(), ctx.getEnvelope());
@@ -162,9 +162,9 @@ public class SymmetricBindingBuilderTest extends MessageBuilderTestBase {
         
         list.add(new QName(WSConstants.WSU_NS, WSConstants.TIMESTAMP_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_KEY_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.SIG_NS, WSConstants.SIG_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02, ConversationConstants.DERIVED_KEY_TOKEN_LN));
+        list.add(new QName(ConversationConstants.WSC_NS_05_12, ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.REF_LIST_LN));
 
         

--- a/modules/rampart-tests/src/test/java/org/apache/rampart/TransportBindingBuilderTest.java
+++ b/modules/rampart-tests/src/test/java/org/apache/rampart/TransportBindingBuilderTest.java
@@ -79,7 +79,7 @@ public class TransportBindingBuilderTest extends MessageBuilderTestBase {
         list.add(new QName(WSConstants.WSU_NS, WSConstants.TIMESTAMP_TOKEN_LN));
         list.add(new QName(WSConstants.WSSE_NS, WSConstants.USERNAME_TOKEN_LN));
         list.add(new QName(WSConstants.ENC_NS, WSConstants.ENC_KEY_LN));
-        list.add(new QName(ConversationConstants.WSC_NS_05_02,
+        list.add(new QName(ConversationConstants.WSC_NS_05_12,
                            ConversationConstants.DERIVED_KEY_TOKEN_LN));
         list.add(new QName(WSConstants.SIG_NS, WSConstants.SIG_LN));
         this.verifySecHeader(list.iterator(), ctx.getEnvelope());


### PR DESCRIPTION
The default namespace for a derived key token now uses the Oasis URL, so references need to be changed accordingly in test code.