### PR TITLE
Use explicit symmetric key

### DIFF
--- a/modules/rampart-core/src/main/java/org/apache/rampart/builder/AsymmetricBindingBuilder.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/builder/AsymmetricBindingBuilder.java
@@ -908,7 +908,15 @@ public class AsymmetricBindingBuilder extends BindingBuilder {
      */
     private void createEncryptedKey(RampartMessageData rmd, Token token) throws RampartException {
         //Set up the encrypted key to use
-        encrKey = this.getEncryptedKeyBuilder(rmd, token);
+        KeyGenerator keyGen;
+        try {
+            keyGen = KeyUtils.getKeyGenerator(WSConstants.AES_128);
+        } catch (WSSecurityException e) {
+            e.printStackTrace();
+            return;
+        }
+        SecretKey symmetricKey = keyGen.generateKey();
+        encrKey = this.getEncryptedKeyBuilder(rmd, token, symmetricKey);
 
         Element bstElem = encrKey.getBinarySecurityTokenElement();
         if (bstElem != null) {
@@ -920,7 +928,7 @@ public class AsymmetricBindingBuilder extends BindingBuilder {
         encrTokenElement = encrKey.getEncryptedKeyElement();
         this.encrTokenElement = RampartUtil.appendChildToSecHeader(rmd,
                 encrTokenElement);
-        encryptedKeyValue = encrKey.getEncryptedKeySHA1().getBytes();
+        encryptedKeyValue = symmetricKey.getEncoded();
         encryptedKeyId = encrKey.getId();
 
         //Store the token for client - response verification 

--- a/modules/rampart-core/src/main/java/org/apache/rampart/builder/BindingBuilder.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/builder/BindingBuilder.java
@@ -210,7 +210,7 @@ public abstract class BindingBuilder {
      * @return WSSecEncryptedKey encrypted key
      * @throws RampartException If an error occurred getting the WSSecEncryptedKey
      */
-    protected WSSecEncryptedKey getEncryptedKeyBuilder(RampartMessageData rmd, Token token) throws RampartException {
+    protected WSSecEncryptedKey getEncryptedKeyBuilder(RampartMessageData rmd, Token token, SecretKey symmetricKey) throws RampartException {
         
         RampartPolicyData rpd = rmd.getPolicyData();
         Document doc = rmd.getDocument();
@@ -225,8 +225,6 @@ public abstract class BindingBuilder {
             encrKey.setKeyEncAlgo(rpd.getAlgorithmSuite().getAsymmetricKeyWrap());
             
             log.debug("getEncryptedKeyBuilder() setting KeyEncAlgo to value: " + rpd.getAlgorithmSuite().getAsymmetricKeyWrap());
-            KeyGenerator keyGen = KeyUtils.getKeyGenerator(WSConstants.AES_128);
-            SecretKey symmetricKey = keyGen.generateKey();
             encrKey.prepare(RampartUtil.getEncryptionCrypto(rpd.getRampartConfig(), rmd.getCustomClassLoader()), symmetricKey);
             
             return encrKey;

--- a/modules/rampart-core/src/main/java/org/apache/rampart/builder/BindingBuilder.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/builder/BindingBuilder.java
@@ -215,7 +215,7 @@ public abstract class BindingBuilder {
         RampartPolicyData rpd = rmd.getPolicyData();
         Document doc = rmd.getDocument();
         
-        WSSecEncryptedKey encrKey = new WSSecEncryptedKey(doc);
+        WSSecEncryptedKey encrKey = new WSSecEncryptedKey(rmd.getSecHeader());
         
         try {
             RampartUtil.setKeyIdentifierType(rmd, encrKey, token);

--- a/modules/rampart-core/src/main/java/org/apache/rampart/builder/SymmetricBindingBuilder.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/builder/SymmetricBindingBuilder.java
@@ -32,7 +32,7 @@ import org.apache.wss4j.dom.WSConstants;
 import org.apache.wss4j.dom.engine.WSSecurityEngineResult;
 import org.apache.wss4j.common.ext.WSSecurityException;
 import org.apache.wss4j.dom.handler.WSHandlerConstants;
-import org.apache.wss4j.dom.handler.WSHandlerResult;;
+import org.apache.wss4j.dom.handler.WSHandlerResult;
 import org.apache.wss4j.dom.message.WSSecDKEncrypt;
 import org.apache.wss4j.dom.util.WSSecurityUtil;
 import org.apache.wss4j.dom.message.WSSecEncrypt;
@@ -47,12 +47,14 @@ import org.apache.ws.secpolicy.model.X509Token;
 import org.apache.wss4j.common.WSEncryptionPart;
 import org.apache.wss4j.common.derivedKey.ConversationConstants;
 import org.apache.wss4j.common.token.SecurityTokenReference;
+import org.apache.wss4j.common.util.KeyUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
+import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -687,10 +689,19 @@ public class SymmetricBindingBuilder extends BindingBuilder {
     private String setupEncryptedKey(RampartMessageData rmd, Token sigToken) 
     throws RampartException {
         try {
+            KeyGenerator keyGen;
+			try {
+				keyGen = KeyUtils.getKeyGenerator(WSConstants.AES_128);
+			} catch (WSSecurityException e) {
+				e.printStackTrace();
+				return null;
+			}
+            SecretKey symmetricKey = keyGen.generateKey();
             WSSecEncryptedKey encrKey = this.getEncryptedKeyBuilder(rmd, 
-                                                                sigToken);
+                                                                sigToken,
+                                                                symmetricKey);
             String id = encrKey.getId();
-            byte[] secret = encrKey.getEncryptedKeySHA1().getBytes();
+            byte[] secret = symmetricKey.getEncoded();
             //Create a rahas token from this info and store it so we can use
             //it in the next steps
     

--- a/modules/rampart-core/src/main/java/org/apache/rampart/builder/TransportBindingBuilder.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/builder/TransportBindingBuilder.java
@@ -51,6 +51,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.crypto.SecretKey;
+import javax.crypto.KeyGenerator;
 import javax.xml.crypto.dsig.Reference;
 import javax.xml.crypto.dsig.SignatureMethod;
 
@@ -209,8 +210,15 @@ public class TransportBindingBuilder extends BindingBuilder {
             //other party's key and then use it as the parent key of the
             // derived keys
             try {
-                
-                WSSecEncryptedKey encrKey = getEncryptedKeyBuilder(rmd, token);
+                KeyGenerator keyGen;
+                try {
+                    keyGen = KeyUtils.getKeyGenerator(WSConstants.AES_128);
+                } catch (WSSecurityException e) {
+                    e.printStackTrace();
+                    return null;
+                }
+                SecretKey symmetricKey = keyGen.generateKey();
+                WSSecEncryptedKey encrKey = getEncryptedKeyBuilder(rmd, token, symmetricKey);
                 
                 Element bstElem = encrKey.getBinarySecurityTokenElement();
                 if(bstElem != null) {


### PR DESCRIPTION
A symmetric key needs to be passed into BindingBuilder.getEncryptedKeyBuilder() so that the encoded contents of that key can be used in a generated key afterwards in both AsymmetricBindingBuilder and SymmetricBindingBuilder