### PR TITLE
Integration fixes

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -133,8 +133,8 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.72</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/modules/rampart-core/pom.xml
+++ b/modules/rampart-core/pom.xml
@@ -71,8 +71,8 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.72</version>
         </dependency>
         <dependency>
             <groupId>org.opensaml</groupId>

--- a/modules/rampart-core/src/main/java/org/apache/rampart/RampartMessageData.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/RampartMessageData.java
@@ -380,8 +380,8 @@ public class RampartMessageData {
                 secHeader.insertSecurityHeader();
             }
 
-            WSSecurityEngine secEngine = new WSSecurityEngine();
-            secEngine.processSecurityHeader(this.document, requestData);
+            //WSSecurityEngine secEngine = new WSSecurityEngine();
+            //secEngine.processSecurityHeader(this.document, requestData);
             
         } catch (AxisFault e) {
             throw new RampartException("errorInExtractingMsgProps", e);

--- a/modules/rampart-integration/pom.xml
+++ b/modules/rampart-integration/pom.xml
@@ -517,7 +517,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
+                    <artifactId>bcprov-jdk18on</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -529,7 +529,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
+                    <artifactId>bcprov-jdk18on</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -541,7 +541,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
+                    <artifactId>bcprov-jdk18on</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -553,7 +553,7 @@
             <exclusions>
                 <exclusion>
                     <groupId>bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
+                    <artifactId>bcprov-jdk18on</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/modules/rampart-integration/pom.xml
+++ b/modules/rampart-integration/pom.xml
@@ -560,12 +560,12 @@
         <dependency>
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-ldap-codec-standalone</artifactId>
-            <version>1.0.0-M33</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-ldap-extras-codec-api</artifactId>
-            <version>1.0.0-M33</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/modules/rampart-integration/src/main/java/org/apache/rahas/PWCallback.java
+++ b/modules/rampart-integration/src/main/java/org/apache/rahas/PWCallback.java
@@ -83,7 +83,7 @@ public class PWCallback implements CallbackHandler {
 
                  */
 
-                if (pc.getUsage() == WSPasswordCallback.USERNAME_TOKEN) {
+                if (pc.getUsage() == WSPasswordCallback.UNKNOWN) {
 
                 	if(pc.getIdentifier().equals("Ron") && pc.getPassword().equals("noR")) {
 

--- a/modules/rampart-integration/src/main/java/org/apache/rampart/PWCallback.java
+++ b/modules/rampart-integration/src/main/java/org/apache/rampart/PWCallback.java
@@ -106,7 +106,7 @@ public class PWCallback implements CallbackHandler {
 
                  */
 
-                if (pc.getUsage() == WSPasswordCallback.USERNAME_TOKEN) {
+                if (pc.getUsage() == WSPasswordCallback.UNKNOWN) {
 
                     if(pc.getIdentifier().equals("Ron") && pc.getPassword().equals("noR")) {
 

--- a/modules/rampart-trust/pom.xml
+++ b/modules/rampart-trust/pom.xml
@@ -73,8 +73,8 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.72</version>
         </dependency>
         <dependency>
             <groupId>org.opensaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -501,13 +501,13 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
-                <version>${bcprov.jdk15.version}</version>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bcprov.jdk18.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
-                <version>${bcprov.jdk15.version}</version>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bcprov.jdk18.version}</version>
             </dependency>
             <dependency>
                 <groupId>xalan</groupId>
@@ -727,7 +727,7 @@
         <wss4j.version>3.0.0</wss4j.version>
         <opensaml.version>4.3.0</opensaml.version>
 
-        <bcprov.jdk15.version>1.70</bcprov.jdk15.version>
+        <bcprov.jdk18.version>1.72</bcprov.jdk18.version>
 
         <failIfNoTests>false</failIfNoTests>
 


### PR DESCRIPTION
Multiple fixes to support the build and test of rampart-integration
- Used UNKNOWN instead of USERNAME_TOKEN to replace the previous USERNAME_TOKEN_UNKNOWN
- Upgraded bouncy castle to JDK 1.8 version 1.72 to solve transitive dependency clash
- Upgraded apache directory server to 2.0.0 to solve transitive dependency clash (big upgrade but only used for test)

Note : This pull request assumes pull requests 8, 9, 10 and 11 are merged already.