### PR TITLE
Resolve remaining issues with Rampart

### DIFF
--- a/modules/rampart-core/src/main/java/org/apache/rampart/builder/AsymmetricBindingBuilder.java
+++ b/modules/rampart-core/src/main/java/org/apache/rampart/builder/AsymmetricBindingBuilder.java
@@ -108,13 +108,14 @@ public class AsymmetricBindingBuilder extends BindingBuilder {
         RampartConfig config = rpd.getRampartConfig();
 
         /*
-         * We need to hold on to these two element to use them as refence in the
-         * case of encypting the signature
+         * We need to hold on to these elements to use them as reference in the
+         * case of encrypting the signature
          */
         Element encrDKTokenElem = null;
         WSSecEncrypt encr = null;
         refList = null;
         WSSecDKEncrypt dkEncr = null;
+        SecretKey symmetricKey = null;
 
         /*
          * We MUST use keys derived from the same token
@@ -171,7 +172,7 @@ public class AsymmetricBindingBuilder extends BindingBuilder {
                     encr = new WSSecEncrypt(secHeader);
 
                     KeyGenerator keyGen = KeyUtils.getKeyGenerator(rpd.getAlgorithmSuite().getEncryption());
-                    SecretKey symmetricKey = keyGen.generateKey();
+                    symmetricKey = keyGen.generateKey();
             
                     //Element refs = encr.encryptForRef(null, encrParts, symmetricKey);
                     //encr.addInternalRefElement(refs);
@@ -330,8 +331,6 @@ public class AsymmetricBindingBuilder extends BindingBuilder {
                     }
                 } else {
                     try {
-                        KeyGenerator keyGen = KeyUtils.getKeyGenerator(rpd.getAlgorithmSuite().getEncryption());
-                        SecretKey symmetricKey = keyGen.generateKey();
                         // Encrypt, get hold of the ref list and add it
                         secondRefList = encr.encryptForRef(null,
                                 secondEncrParts, symmetricKey);
@@ -509,6 +508,7 @@ public class AsymmetricBindingBuilder extends BindingBuilder {
                         this.setupEncryptedKey(rmd, encrToken);
                     }
                     
+                    dkEncr.setTokenIdentifier(this.encryptedKeyId);
                     dkEncr.setCustomValueType(WSConstants.SOAPMESSAGE_NS11 + "#"
                             + WSConstants.ENC_KEY_VALUE_TYPE);
                     dkEncr.setSymmetricEncAlgorithm(algorithmSuite.getEncryption());

--- a/modules/rampart-samples/policy/build.xml
+++ b/modules/rampart-samples/policy/build.xml
@@ -189,7 +189,7 @@
                 </filterset>
             </copy>
 	   		<copy file="${keys.dir}/service.jks" tofile="${temp.dir}/service.jks" overwrite="true"/>
-	   		<copy file="${keys.dir}/sts2024.jks" tofile="${temp.dir}/sts2024.jks" overwrite="true"/>
+	   		<copy file="${keys.dir}/sts.jks" tofile="${temp.dir}/sts.jks" overwrite="true"/>
 	   		<copy file="${keys.dir}/service.properties" tofile="${temp.dir}/service.properties" overwrite="true"/>
 
 	   		<jar destfile="${service.repos.dir}/sample@{sample.number}/services/sample@{sample.number}.aar">
@@ -253,7 +253,7 @@
                 </filterset>
             </copy>
             <copy file="${keys.dir}/service.jks" tofile="${temp.dir}/service.jks" overwrite="true"/>
-            <copy file="${keys.dir}/sts2024.jks" tofile="${temp.dir}/sts2024.jks" overwrite="true"/>
+            <copy file="${keys.dir}/sts.jks" tofile="${temp.dir}/sts.jks" overwrite="true"/>
             <copy file="${keys.dir}/service.properties" tofile="${temp.dir}/service.properties" overwrite="true"/>
 
             <jar destfile="${service.repos.dir}/sample@{sample.number}/services/sample@{sample.number}.aar">

--- a/modules/rampart-samples/policy/sample06/policy.xml
+++ b/modules/rampart-samples/policy/sample06/policy.xml
@@ -87,7 +87,7 @@
 				
 				<ramp:signatureCrypto>
 					<ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">JKS</ramp:property>
 						<ramp:property name="org.apache.ws.security.crypto.merlin.file">client.jks</ramp:property>
 						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
 					</ramp:crypto>
@@ -95,7 +95,7 @@
 				
 				<ramp:stsCrypto>
 			      <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                    <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                    <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">JKS</ramp:property>
                     <ramp:property name="org.apache.ws.security.crypto.merlin.file">client.jks</ramp:property>
                     <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
                   </ramp:crypto>

--- a/modules/rampart-samples/policy/sample06/services.xml
+++ b/modules/rampart-samples/policy/sample06/services.xml
@@ -28,8 +28,8 @@
 			<issuerKeyPassword>apache</issuerKeyPassword>
             		<cryptoProperties>
                			<crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                    		<property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</property>
-                    		<property name="org.apache.ws.security.crypto.merlin.file">sts2024.pkcs12</property>
+                    		<property name="org.apache.ws.security.crypto.merlin.keystore.type">JKS</property>
+                    		<property name="org.apache.ws.security.crypto.merlin.file">sts.jks</property>
                     		<property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</property>
                 		</crypto>
             		</cryptoProperties>
@@ -114,8 +114,8 @@
 					
 					<ramp:signatureCrypto>
 						<ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-							<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
-							<ramp:property name="org.apache.ws.security.crypto.merlin.file">sts2024.pkcs12</ramp:property>
+							<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">JKS</ramp:property>
+							<ramp:property name="org.apache.ws.security.crypto.merlin.file">sts.jks</ramp:property>
 							<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
 						</ramp:crypto>
 					</ramp:signatureCrypto>
@@ -226,7 +226,7 @@
 					
 					<ramp:signatureCrypto>
 						<ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-							<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+							<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">JKS</ramp:property>
 							<ramp:property name="org.apache.ws.security.crypto.merlin.file">service.jks</ramp:property>
 							<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
 						</ramp:crypto>

--- a/modules/rampart-samples/policy/sample07/policy.xml
+++ b/modules/rampart-samples/policy/sample07/policy.xml
@@ -106,14 +106,14 @@
 				<ramp:passwordCallbackClass>org.apache.rampart.samples.policy.sample07.PWCBHandler</ramp:passwordCallbackClass>
 				<ramp:signatureCrypto>
 					<ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
 						<ramp:property name="org.apache.ws.security.crypto.merlin.file">client.jks</ramp:property>
 						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
 					</ramp:crypto>
 				</ramp:signatureCrypto>
 				<ramp:encryptionCypto>
 					<ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
 						<ramp:property name="org.apache.ws.security.crypto.merlin.file">client.jks</ramp:property>
 						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
 					</ramp:crypto>

--- a/modules/rampart-samples/policy/sample07/services.xml
+++ b/modules/rampart-samples/policy/sample07/services.xml
@@ -135,7 +135,7 @@
 
                     <ramp:signatureCrypto>
                         <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                            <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                            <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
                             <ramp:property name="org.apache.ws.security.crypto.merlin.file">service.jks</ramp:property>
                             <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache
                             </ramp:property>
@@ -143,7 +143,7 @@
                     </ramp:signatureCrypto>
                     <ramp:encryptionCypto>
                         <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                            <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                            <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
                             <ramp:property name="org.apache.ws.security.crypto.merlin.file">service.jks</ramp:property>
                             <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache
                             </ramp:property>

--- a/modules/rampart-samples/policy/sample08/services.xml
+++ b/modules/rampart-samples/policy/sample08/services.xml
@@ -28,7 +28,7 @@
 			<issuerKeyPassword>apache</issuerKeyPassword>
             		<cryptoProperties>
                			<crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                    		<property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</property>
+                    		<property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</property>
                     		<property name="org.apache.ws.security.crypto.merlin.file">service.jks</property>
                     		<property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</property>
                 		</crypto>

--- a/modules/rampart-samples/policy/sample08/sts_policy.xml
+++ b/modules/rampart-samples/policy/sample08/sts_policy.xml
@@ -71,7 +71,7 @@
 				
 				<ramp:signatureCrypto>
 					<ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
 						<ramp:property name="org.apache.ws.security.crypto.merlin.file">client.jks</ramp:property>
 						<ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
 					</ramp:crypto>

--- a/modules/rampart-samples/policy/sample09/client_in_policy.xml
+++ b/modules/rampart-samples/policy/sample09/client_in_policy.xml
@@ -57,10 +57,9 @@
 
             <ramp:signatureCrypto>
                 <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                    <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                    <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
                     <ramp:property name="org.apache.ws.security.crypto.merlin.file">client.jks</ramp:property>
-                    <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache
-                    </ramp:property>
+                    <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
                 </ramp:crypto>
             </ramp:signatureCrypto>
 

--- a/modules/rampart-samples/policy/sample09/client_out_policy.xml
+++ b/modules/rampart-samples/policy/sample09/client_out_policy.xml
@@ -58,18 +58,16 @@
 
                 <ramp:encryptionCypto>
                     <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                        <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                        <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
                         <ramp:property name="org.apache.ws.security.crypto.merlin.file">client.jks</ramp:property>
-                        <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache
-                        </ramp:property>
+                        <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
                     </ramp:crypto>
                 </ramp:encryptionCypto>
                 <ramp:signatureCrypto>
                     <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                        <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                        <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
                         <ramp:property name="org.apache.ws.security.crypto.merlin.file">client.jks</ramp:property>
-                        <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache
-                        </ramp:property>
+                        <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
                     </ramp:crypto>
                 </ramp:signatureCrypto>
             </ramp:RampartConfig>

--- a/modules/rampart-samples/policy/sample09/services.xml
+++ b/modules/rampart-samples/policy/sample09/services.xml
@@ -90,18 +90,16 @@
 
                         <ramp:encryptionCypto>
                             <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
                                 <ramp:property name="org.apache.ws.security.crypto.merlin.file">service.jks</ramp:property>
-                                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache
-                                </ramp:property>
+                                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
                             </ramp:crypto>
                         </ramp:encryptionCypto>
                         <ramp:signatureCrypto>
                             <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
                                 <ramp:property name="org.apache.ws.security.crypto.merlin.file">service.jks</ramp:property>
-                                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache
-                                </ramp:property>
+                                <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
                             </ramp:crypto>
                         </ramp:signatureCrypto>
                         
@@ -174,10 +172,9 @@
 
                     <ramp:signatureCrypto>
                         <ramp:crypto provider="org.apache.ws.security.components.crypto.Merlin">
-                            <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">pkcs12</ramp:property>
+                            <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.type">jks</ramp:property>
                             <ramp:property name="org.apache.ws.security.crypto.merlin.file">service.jks</ramp:property>
-                            <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache
-                            </ramp:property>
+                            <ramp:property name="org.apache.ws.security.crypto.merlin.keystore.password">apache</ramp:property>
                         </ramp:crypto>
                     </ramp:signatureCrypto>
                     


### PR DESCRIPTION
## Integration Tests

### Change 1
The following line was removed from `AsymmetricBindingBuilder` (line 501 originally) as the document was passed in the constructor and the call is no longer available in wss4j.

`dkEncr.setExternalKey(this.encryptedKeyValue, this.encryptedKeyId); `

This meant that the tokenid was never being set up, so I added the following

`dkEncr.setTokenIdentifier(this.encryptedKeyId);`

### Change 2
`processSecurityHeaderWithRSA15()` needed to be refactored so that `requestData.setAllowUsernameTokenNoPassword(true);` could be applied correctly. 
Previously, this was ignored as a new `RequestData` was created after applying it.

### Change 3

In `AsymmetricBindingBuilder.doEncryptBeforeSig` the `symmetricKey` variable needed to be retained (rather than recreated) for use when calling `secondRefList = encr.encryptForRef()`

## Samples

Essentially I removed all references to `sts2024.pkcs12` as itś not necessary (existing certs are all valid until after 2030) and the partial application of it was failing.




